### PR TITLE
Do not typehint for “object"

### DIFF
--- a/src/InterNations/Component/Testing/AccessTrait.php
+++ b/src/InterNations/Component/Testing/AccessTrait.php
@@ -41,6 +41,7 @@ trait AccessTrait
     /**
      * Call private and protected methods on an object
      *
+     * @param object|string $object
      * @param mixed[] $args
      * @return mixed
      */

--- a/src/InterNations/Component/Testing/AccessTrait.php
+++ b/src/InterNations/Component/Testing/AccessTrait.php
@@ -44,7 +44,7 @@ trait AccessTrait
      * @param mixed[] $args
      * @return mixed
      */
-    protected static function callNonPublicMethod(object $object, string $methodName, array $args = [])
+    protected static function callNonPublicMethod($object, string $methodName, array $args = [])
     {
         $class = new ReflectionClass($object);
         $method = $class->getMethod($methodName);


### PR DESCRIPTION
This package is still on php ~7.0 as minimum requirement. We cannot typehint for “object”, it’s a PHP 7.2 feature.