### PR TITLE
added ability to configure container parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,6 @@
         "symfony/css-selector": "Dependency for symfony/dom-crawler"
     },
     "require": {
-        "php": "~7"
+        "php": "~7.1"
     }
 }

--- a/src/InterNations/Component/Testing/ContainerTestTrait.php
+++ b/src/InterNations/Component/Testing/ContainerTestTrait.php
@@ -18,15 +18,17 @@ trait ContainerTestTrait
     /**
      * @param mixed[] $config
      * @param Definition[] $definitions
+     * @param mixed[] $parameters
      */
     protected function createContainer(
         ?string $file = null,
         bool $debug = false,
         array $config = [],
-        array $definitions = []
+        array $definitions = [],
+        array $parameters = []
     ): ContainerBuilder
     {
-        $container = new ContainerBuilder(new ParameterBag(['kernel.debug' => $debug]));
+        $container = new ContainerBuilder(new ParameterBag(['kernel.debug' => $debug] + $parameters));
         $container->registerExtension($this->getContainerExtension());
 
         $this->loadFromFile($container, $file);
@@ -62,7 +64,7 @@ trait ContainerTestTrait
                 $loader = new YamlFileLoader($container, $locator);
                 break;
 
-            case 'xml':
+            case 'php':
                 $loader = new PhpFileLoader($container, $locator);
                 break;
 


### PR DESCRIPTION
Added ability to pass container parameters to the container, cause some mandatory parameters are missing by default, like "kernel.environment" and they are required in some test cases
Small fixes:
1. Fixed duplicate switch case, xml was defined twice
2. Increased php requirement version because we use scalar typehints, like nullable string